### PR TITLE
カスタムファイル名中にオリジナルファイル名を挿入可能にしました。

### DIFF
--- a/app/pages/options/components/DownloadToField.tsx
+++ b/app/pages/options/components/DownloadToField.tsx
@@ -3,7 +3,7 @@ import { Component } from 'react';
 import styled from 'styled-components';
 import { AppColor } from '../Colors';
 import { TextField } from './TextField';
-import { TagUserId, TagTweetId, TagImageIndex, TagExtension, DefaultFilename } from '../../../scripts/Setting';
+import { TagUserId, TagTweetId, TagImageIndex, TagOriginal, TagExtension, DefaultFilename } from '../../../scripts/Setting';
 import { SetToDefaultButton } from './SetToDefaultButton';
 
 const InvalidWithEmptyFilename = "Directory name or filename name can not set to an empty.";
@@ -108,11 +108,12 @@ export class DownloadToField extends Component<Property>{
             <InformationText>{`e.g. "${TagUserId}/${TagTweetId}.${TagExtension}" makes directory for each users.`}</InformationText>
           </Paragraph>
           <Paragraph>
-            <InformationText>{`You can use followings.`}</InformationText>
-            <InformationText>{`${TagUserId} : user id`}</InformationText>
-            <InformationText>{`${TagTweetId} : tweet id`}</InformationText>
-            <InformationText>{`${TagImageIndex} : index of image (1...4). if image was single, replace with "1"`}</InformationText>
-            <InformationText>{`${TagExtension} : "png" or "jpg"`}</InformationText>
+            <InformationText>{`You can use following variables.`}</InformationText>
+            <InformationText>{`${TagUserId} : User ID`}</InformationText>
+            <InformationText>{`${TagTweetId} : Tweet ID`}</InformationText>
+            <InformationText>{`${TagImageIndex} : Index of image (0...3). If there is a single image, the number will be "0".`}</InformationText>
+            <InformationText>{`${TagOriginal} : Original file name`}</InformationText>
+            <InformationText>{`${TagExtension} : File extension ("png" or "jpg").`}</InformationText>
           </Paragraph>
           <Paragraph>
             <InformationText>{`Default value is "TwitterImageDLer/${DefaultFilename}".`}</InformationText>

--- a/app/pages/options/components/OptionsForm.tsx
+++ b/app/pages/options/components/OptionsForm.tsx
@@ -5,7 +5,7 @@ import { SaveButton } from './SaveButton';
 import { Spinner } from './Spinner';
 import { DownloadToField } from './DownloadToField';
 import { EnableSaveAsField } from './EnableSaveAsField';
-import { CreateDefaultSetting, Setting, IsLatestDataVersion, MigrateSetting1to2, TagUserId, TagTweetId, TagImageIndex, TagExtension } from '../../../scripts/Setting';
+import { CreateDefaultSetting, Setting, IsLatestDataVersion, MigrateSetting1to2, TagUserId, TagTweetId, TagImageIndex, TagOriginal, TagExtension } from '../../../scripts/Setting';
 
 const Layout = styled.div`
   display: flex;
@@ -90,6 +90,7 @@ export class OptionsForm extends Component<any, OptionState>{
     s = s.replace(TagUserId, "");
     s = s.replace(TagTweetId, "");
     s = s.replace(TagImageIndex, "");
+    s = s.replace(TagOriginal, "");
     s = s.replace(TagExtension, "");
     return !(s.includes("<") || s.includes(">"));
   }

--- a/app/scripts/ImageInfo.ts
+++ b/app/scripts/ImageInfo.ts
@@ -1,4 +1,4 @@
-import { TagUserId, TagTweetId, TagImageIndex, TagExtension } from "./Setting";
+import { TagUserId, TagTweetId, TagImageIndex, TagOriginal, TagExtension } from "./Setting";
 
 const twimgBase: string = 'https://pbs.twimg.com/media/';
 
@@ -99,6 +99,7 @@ export class ImageInfoImpl implements ImageInfo {
 		filename = filename.replace(TagUserId, this.username);
 		filename = filename.replace(TagTweetId, this.tweetId);
 		filename = filename.replace(TagImageIndex, this.imageIndex.toString());
+		filename = filename.replace(TagOriginal, this.twimgUrl.path)
 		filename = filename.replace(TagExtension, this.twimgUrl.extension);
 		return filename;
 	}

--- a/app/scripts/Setting.ts
+++ b/app/scripts/Setting.ts
@@ -3,6 +3,7 @@ const LatestDataVersion: number = 2;
 export const TagUserId: string = "<userid>";
 export const TagTweetId: string = "<tweetid>";
 export const TagImageIndex: string = "<imageindex>";
+export const TagOriginal: string = "<original>"
 export const TagExtension: string = "<ext>";
 
 export const DefaultFilename: string = `${TagUserId}-${TagTweetId}-${TagImageIndex}.${TagExtension}`;


### PR DESCRIPTION
個人的な利用のために、カスタムファイル名の中にオリジナルファイル名(twimgパス)を挿入できるように、オプションの変数を追加させていただきました。Google Chrome 83.0 でおおまかに動作を確認しました。
実のところ私は完全なるコーディング初心者で、TypeScriptやGitの経験もまったくありません（プルリクエストなるものを送信させていただくことも初めてです）。ですので、もし私の行動に不適切な部分や失礼がありましたら、お詫び申し上げます。
もし差し支えがなければ、こちらの機能をマージしていただけましたら光栄に存じます（もちろん、HassakuTbさんのご都合を優先していただいてかまいません）。